### PR TITLE
fix 1.1 formula derivative of cost function

### DIFF
--- a/docs/Neural_Networks_and_Deep_Learning/神经网络基础.md
+++ b/docs/Neural_Networks_and_Deep_Learning/神经网络基础.md
@@ -88,13 +88,13 @@ $$b:=b−\alpha db$$
 
 接下来我们需要将对于单个用例的损失函数扩展到整个训练集的代价函数：
 
-$$J(w,b)=\frac{1}{m}\sum^m_{i=1}L(a^{(i)},y)$$ 
+$$J(w,b)=\frac{1}{m}\sum^m_{i=1}L(a^{(i)},y^{(i)})$$ 
 
 $$a^{(i)}=\hat{y}^{(i)}=\sigma(z^{(i)})=\sigma(w^Tx^{(i)}+b)$$
 
 我们可以对于某个权重参数 w1，其导数计算为：
 
-$$\frac{\partial J(w,b)}{\partial{w\_1}}=\frac{1}{m}\sum^m_{i=1}\frac{\partial}{\partial{w\_1}L(a^{(i)},y^{(i)})}$$
+$$\frac{\partial J(w,b)}{\partial{w\_1}}=\frac{1}{m}\sum^m_{i=1}\frac{\partial L(a^{(i)},y^{(i)})}{\partial{w\_1}}$$
 
 
 完整的 Logistic 回归中某次训练的流程如下，这里仅假设特征向量的维度为 2：


### PR DESCRIPTION
LR 梯度下降法中, 整个训练集的代价函数J(w,b)中, 修正y为y^i; J(w,b)对w1的导数计算求和项L(ai,yi)修正到分子上